### PR TITLE
Make Plugins use interpolated Grunt templates (e.g. BannerPlugin)

### DIFF
--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -28,14 +28,17 @@ module.exports = function(grunt) {
 				// the array won't a BannerPlugin, it will contain an Object)
 				obj.plugins = grunt.config.getRaw(ns.concat(["plugins"]));
 
-				// Re-interpolate plugin string properties as templates
-				obj.plugins.forEach(function(plugin) {
-					for (var key in plugin) {
-						plugin.hasOwnProperty(key);
-						if (typeof plugin[key] === "string") {
-							plugin[key] = grunt.template.process(plugin[key]);
+				// See https://github.com/webpack/grunt-webpack/pull/9
+				obj.plugins = obj.plugins.map(function(plugin) {
+					var instance = Object.create(plugin); // Operate on a copy of the plugin, since the webpack task
+					                                      // can be called multiple times for one instance of a plugin
+					for(var key in plugin) {
+						// Re-interpolate plugin string properties as templates
+						if(Object.prototype.hasOwnProperty.call(plugin, key) && typeof plugin[key] === "string") {
+							instance[key] = grunt.template.process(plugin[key]);
 						}
 					}
+					return instance;
 				});
 			}
 			return obj;


### PR DESCRIPTION
The BannerPlugin isn't interpolating the template I am passing in, which
will just about always be the case for someone using it.  I investigated
and it looks like the culprit is in grunt-webpack/tasks/webpack.js:

``` javascript
function getWithPlugins(ns) {
  var obj = grunt.config(ns);
  if(obj.plugins) obj.plugins =
    grunt.config.getRaw(ns.concat(["plugins"]));
  return obj;
}
```

This is clobbering the interpolated text with uninterpolated text.  I
understand why: `grunt.config()` turned the plugin objects into generic
Object instances and `grunt.config.getRaw()` restores them to plugin
instances, e.g. `BannerPlugin`.  The only problem is that grunt templates
end up being reverted too.

This fixes that issue by enumerating all the plugin properties and
processing any strings through `grunt.template.process()`.
