### PR TITLE
Make options.plugins optional

### DIFF
--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
 
 		// Get options from this.data
 		function getWithPlugins(ns) {
-			var obj = grunt.config(ns);
+			var obj = grunt.config(ns) || {};
 			if(obj.plugins) {
 				// getRaw must be used or grunt.config will clobber the types (i.e.
 				// the array won't a BannerPlugin, it will contain an Object)


### PR DESCRIPTION
Otherwise it will abort with the warning:

```
Warning: Cannot read property 'plugins' of undefined Use --force to continue.
```
