### PR TITLE
Implemented the 'resolve.root' option for webpack.

### DIFF
--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -64,7 +64,11 @@ module.exports = function(grunt) {
 			}
 			else if(_.isArray(pth)){
 				return _.map(pth, function(p){
-					return path.resolve(process.cwd(), p);
+					// Arrays of paths can contain a mix of both strings and RegExps
+					if(_.isString(p)){
+						return path.resolve(process.cwd(), p);
+					}
+					return p
 				});
 			}
 			// It may have been a RegExp so just send it back


### PR DESCRIPTION
My project has a few different src directories that webpack needs to access to pull various resources.  All of the other paths in the options for the task are converted to absolute paths, but the paths for resolve.root weren't getting converted so webpack couldn't find my resources.

My webpack.config.js looked something like the below.  This pull request updates the paths in the root so that webpack can find all the necessary resources.

resolve: {
    root: [
      __dirname + "/src/stylus"
    ],
    extensions: ["", ".coffee", ".js", ".styl"]
  },

Hope it works well for you ;)

Cheers,
Simon
